### PR TITLE
캘린더 - 캘린더 훅 수정 및 API 쿼리 연결 

### DIFF
--- a/src/api/calendar/calendar.tsx
+++ b/src/api/calendar/calendar.tsx
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+import { axiosRequest } from '../index';
+import { ApiResponse } from '@/types/api.types';
+
+type CalendarEventsProps = {
+  pet_id: number;
+  year: number;
+  month: number;
+};
+
+type CalendarEventsResponse = {
+  date: string;
+  event_exist: boolean;
+  diary_exist: boolean;
+};
+
+export const calendarEvents = (
+  props: CalendarEventsProps
+): Promise<ApiResponse<CalendarEventsResponse[]>> => {
+  const data = {
+    ...props,
+  };
+
+  return axiosRequest.get('/calendar', { data });
+};
+
+export const useCalendarEvents = (props: CalendarEventsProps) => {
+  return useQuery(
+    ['calendar-events', props.pet_id],
+    () => calendarEvents({ ...props }),
+    {
+      enabled: Boolean(props.pet_id),
+    }
+  );
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export const axiosRequest = axios.create({
+  // baseURL: 'https://some-domain.com/api/',
+  //   headers: { 'X-Custom-Header': 'foobar' },
+});

--- a/src/components/page/home/calendar/mark/index.tsx
+++ b/src/components/page/home/calendar/mark/index.tsx
@@ -9,9 +9,6 @@ const Mark = ({ items }: MarkProps) => {
             {type === 'TODO' && (
               <div key={type} aria-label="일정" className={style.todo} />
             )}
-            {type === 'PICTURE' && (
-              <div key={type} aria-label="사진" className={style.picture} />
-            )}
             {type === 'DIARY' && (
               <div key={type} aria-label="일기" className={style.diary} />
             )}
@@ -23,7 +20,7 @@ const Mark = ({ items }: MarkProps) => {
 };
 
 type MarkProps = {
-  items: ('TODO' | 'PICTURE' | 'DIARY')[];
+  items: ('TODO' | 'DIARY')[];
 };
 
 export default Mark;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,7 +6,11 @@ import HomeHeader from '@/components/headers/home';
 
 import type { NextPage } from 'next';
 import { useEffect, type ReactElement } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  Hydrate,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
 import { RecoilRoot } from 'recoil';
 
 import { serviceWorker } from '@mocks/browser';
@@ -32,11 +36,13 @@ export default function App({ Component, pageProps }: AppPropsWithHeader) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <RecoilRoot>
-        <Layout header={header}>
-          <Component {...pageProps} />
-        </Layout>
-      </RecoilRoot>
+      <Hydrate state={pageProps.dehydratedState}>
+        <RecoilRoot>
+          <Layout header={header}>
+            <Component {...pageProps} />
+          </Layout>
+        </RecoilRoot>
+      </Hydrate>
     </QueryClientProvider>
   );
 }

--- a/src/utils/hooks/use-calendar.tsx
+++ b/src/utils/hooks/use-calendar.tsx
@@ -24,8 +24,8 @@ const useCalendar = () => {
       (month === 'NEXT' && newDate.month + 1) ||
       newDate.month;
 
-    newDate.day = value;
     newDate.month = newMonth - 1;
+    newDate.day = value;
 
     setDate(newDate);
     setSelectedDate(newDate.format('YYYY-MM-DD'));
@@ -53,12 +53,12 @@ const useCalendar = () => {
 
   const convertToFormat = (day: number) => {
     const isLastMonth = day < 0;
-    const isNextMonth = day > lastDayOfThisMonth();
+    const isNextMonth = day > lastDayOfThisMonth() - 1;
 
     return {
       value:
         (isLastMonth && day + lastDayofLasMonth() + 1) ||
-        (isNextMonth && day - lastDayOfThisMonth()) ||
+        (isNextMonth && day - lastDayOfThisMonth() + 1) ||
         day + 1,
       month: (isLastMonth && 'LAST') || (isNextMonth && 'NEXT') || 'CURRENT',
     } as State;
@@ -69,7 +69,7 @@ const useCalendar = () => {
     const days: State[][] = [];
 
     const start = -1 * firstWeekOfThisMonth();
-    const end = lastDayOfThisMonth() + lastWeekOfThisMonth();
+    const end = lastDayOfThisMonth() + (6 - lastWeekOfThisMonth());
 
     for (let day = start; day < end; day += 1) {
       const week = convertToFormat(day);


### PR DESCRIPTION
- useCalendar 훅에서 반환하는 days 값의 게산이 올바르지 못하여 이를 수정했어요!
- 페이지 내 query 호출을 위한 별도의 쿼리 훅을 만들었어요! 
> /src/api 폴더를 만들고 해당 폴더 하위로 관심사에 따라 api 를 분리했어요
> calendar 의 경우 /src/api/calendar 폴더를 만들고 하위에 calendar.tsx 파일을 만들었어요 
> 해당 파일에는 API fetching 함수와 useQuery 를 사용하기 위해 한 번 더 감싼 custom hook 이 있어요. 이렇게 함으로써 API 를 사용하는 쪽에서 더 간결하게 사용할 수 있도록 했어요 
- 페이지 prefetching 을 위해 Hydrate 설정을 했어요 
> SSR 페이지에서 데이터를 prefetching 하여 페이지 컴포넌트에 전파할 수 있도록 tanstack query 에서 제공하는 Hydrate 컴포넌트를 최상단 앱 컴포넌트에 선언했어요 
> 다만 아직 백엔드 서버가 띄워지기 전이라 API call 하는 부분은 주석으로 처리했어요! 
- API 요청을 위한 axios 인스턴스를 공통으로 선언하였어요! 